### PR TITLE
[#141]: fix the backend setting can not be config by environment variable.

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -14,7 +14,7 @@ nconf.defaults({
     // trailing slash
     "path": process.env.DB_PATH || "db",
     // s3 or fs
-    "backend": "s3"
+    "backend": process.env.BACKEND || "s3"
   }
   , "express": {
     "secret": "a random session secret"


### PR DESCRIPTION
as title.
