### PR TITLE
Changing "contact us" link to discuss.okfn.org

### DIFF
--- a/views/base.html
+++ b/views/base.html
@@ -50,7 +50,7 @@
       <ul class="nav pull-right">
         <li class="divider-vertical"></li>
         <li>
-          <a href="http://okfnlabs.org/contact">{{ gettext('Contact Us') }}</a>
+          <a href="https://discuss.okfn.org/c/open-knowledge-labs/timemapper">{{ gettext('Contact Us') }}</a>
         </li>
         <li class="divider-vertical"></li>
         <li>


### PR DESCRIPTION
Currently, lots of support requests land in the labs@okfn.org mailbox. This change directs people instead to the relevant discuss.okfn.org forum topic.